### PR TITLE
Fix compilation errors and warnings on Elixir 1.2.0

### DIFF
--- a/lib/map_diff_ex.ex
+++ b/lib/map_diff_ex.ex
@@ -66,10 +66,10 @@ defmodule MapDiffEx do
     case {minify, MinifiedListDiff.diff(checksums1, checksums2)} do
       {_, nil}   -> {list1, list2}
       {false, _} -> {list1, list2}
-      {true, {:right, index, elem_hash}} ->
+      {true, {:right, index, _}} ->
         elem = Enum.at(list2, index)
         {"#{length(list1)} element List", {"List with additional element", elem}}
-      {true, {:left, index, elem_hash}} ->
+      {true, {:left, index, _}} ->
         elem = Enum.at(list1, index)
         {{"List with additional element", elem}, "#{length(list2)} element List"}
     end

--- a/lib/map_diff_ex.ex
+++ b/lib/map_diff_ex.ex
@@ -122,7 +122,7 @@ defmodule MapDiffEx do
 
   defp filter_nil_values(list) do
     list
-    |> Enum.reject(fn({_key, value} -> is_nil(value)) end)
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
   end
 
   defp filter_empty_list([]), do: nil

--- a/lib/minified_list_diff.ex
+++ b/lib/minified_list_diff.ex
@@ -13,8 +13,8 @@ defmodule MinifiedListDiff do
   end
 
   defp do_diff([head | tail1], [head | tail2], acc), do: do_diff(tail1, tail2, acc)
-  defp do_diff([head,a2 | tail1], [b1, head | tail2], acc), do: do_diff(tail1, tail2, {b1})
-  defp do_diff([a1,head | tail1], [head, b2 | tail2], acc), do: do_diff(tail1, tail2, {a1})
+  defp do_diff([head, _ | tail1], [b1, head | tail2], _), do: do_diff(tail1, tail2, {b1})
+  defp do_diff([a1, head | tail1], [head, _ | tail2], _), do: do_diff(tail1, tail2, {a1})
   defp do_diff([head | []], [head | []], acc), do: acc
   defp do_diff([head | []], [], nil), do: head
   defp do_diff([], [head | []], nil), do: head

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MapDiffEx.Mixfile do
   def project do
     [app: :map_diff_ex,
      version: "0.0.1",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      deps: deps]
   end
 


### PR DESCRIPTION
This builds clean on Elixir 1.2.0. 

Please note that I just replaced unused variables with an underscore, where an underscore prefix (e.g. `_acc`) would also make the warnings go away. Not sure what you prefer.
