### PR TITLE
Allow custom key_not_set marker

### DIFF
--- a/lib/map_diff_ex.ex
+++ b/lib/map_diff_ex.ex
@@ -8,6 +8,7 @@ defmodule MapDiffEx do
   defp do_diff(map1, map2, _options) when map1 == map2, do: nil
   defp do_diff(map1, map2, options) when is_map(map1) and is_map(map2) do
     ignore_keys = options[:ignore] || []
+    key_not_set_marker = options[:key_not_set_marker] || :key_not_set
     Dict.keys(map1) ++ Dict.keys(map2)
     |> Enum.uniq
     |> Enum.map(fn key ->
@@ -15,8 +16,8 @@ defmodule MapDiffEx do
         Enum.member?(ignore_keys, key |> Atom.to_string) ->
           {key, nil}
         true ->
-          value1 = Dict.get(map1, key, :key_not_set)
-          value2 = Dict.get(map2, key, :key_not_set)
+          value1 = Dict.get(map1, key, key_not_set_marker)
+          value2 = Dict.get(map2, key, key_not_set_marker)
           next_level_options = Dict.put(options, :ignore, ignore_keys |> strip_prefix_from_string_list(key))
 
           { key, do_diff(value1, value2, next_level_options) }

--- a/test/map_diff_ex_test.exs
+++ b/test/map_diff_ex_test.exs
@@ -96,6 +96,14 @@ defmodule MapDiffExTest do
     assert diff(map1, map2) == expected_diff
   end
 
+  test "should allow a custom 'key_not_set' marker" do
+    map1 = %{a: 1}
+    map2 = %{}
+
+    expected_diff = %{a: {1, "KEY_NOT_SET"}}
+    assert diff(map1, map2, %{key_not_set_marker: "KEY_NOT_SET"}) == expected_diff
+  end
+
   test "should handle sub maps" do
     map1 = %{a: %{b: 2}}
     map2 = %{a: %{b: 3}}


### PR DESCRIPTION
Add `:key_not_set_marker` option. This is useful when printing the diff via `Apex.Format.format`, which will pick a special formatting rule if the the first element of a Tuple is an Atom (`:key_not_set`).
So by using a string (e.g. `diff(map1, map2, %{key_not_set_marker: "KEY_NOT_SET"})`), we can change that where needed.
